### PR TITLE
chore: lots

### DIFF
--- a/lib/gateway.ts
+++ b/lib/gateway.ts
@@ -13,7 +13,7 @@ import { connection_init } from './messages/connection_init'
 import { pong } from './messages/pong'
 
 export const handleGatewayEvent =
-  (c: ServerClosure): Handler<APIGatewayWebSocketEvent, WebsocketResponse> =>
+  (server: ServerClosure): Handler<APIGatewayWebSocketEvent, WebsocketResponse> =>
     async (event) => {
       if (!event.requestContext) {
         return {
@@ -23,7 +23,7 @@ export const handleGatewayEvent =
       }
 
       if (event.requestContext.eventType === 'CONNECT') {
-        await c.onConnect?.({ event })
+        await server.onConnect?.({ event })
         return {
           statusCode: 200,
           headers: {
@@ -37,7 +37,7 @@ export const handleGatewayEvent =
         const message = JSON.parse(event.body!)
 
         if (message.type === MessageType.ConnectionInit) {
-          await connection_init({ c, event, message })
+          await connection_init({ server, event, message })
           return {
             statusCode: 200,
             body: '',
@@ -45,7 +45,7 @@ export const handleGatewayEvent =
         }
 
         if (message.type === MessageType.Subscribe) {
-          await subscribe({ c, event, message })
+          await subscribe({ server, event, message })
           return {
             statusCode: 200,
             body: '',
@@ -53,7 +53,7 @@ export const handleGatewayEvent =
         }
 
         if (message.type === MessageType.Complete) {
-          await complete({ c, event, message })
+          await complete({ server, event, message })
           return {
             statusCode: 200,
             body: '',
@@ -61,7 +61,7 @@ export const handleGatewayEvent =
         }
 
         if (message.type === MessageType.Ping) {
-          await ping({ c, event, message })
+          await ping({ server, event, message })
           return {
             statusCode: 200,
             body: '',
@@ -69,7 +69,7 @@ export const handleGatewayEvent =
         }
 
         if (message.type === MessageType.Pong) {
-          await pong({ c, event, message })
+          await pong({ server, event, message })
           return {
             statusCode: 200,
             body: '',
@@ -78,7 +78,7 @@ export const handleGatewayEvent =
       }
 
       if (event.requestContext.eventType === 'DISCONNECT') {
-        await disconnect({ c, event, message: null })
+        await disconnect({ server, event, message: null })
         return {
           statusCode: 200,
           body: '',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,29 +1,12 @@
-import { DataMapper } from '@aws/dynamodb-data-mapper'
-import { ServerArgs } from './types'
+import { ServerArgs, ServerClosure } from './types'
 import { publish } from './pubsub/publish'
 import { complete } from './pubsub/complete'
-import { createModel } from './model/createModel'
-import { Subscription } from './model/Subscription'
 import { handleGatewayEvent } from './gateway'
 import { handleStateMachineEvent } from './stepFunctionHandler'
-import { Connection } from './model/Connection'
+import { makeServerClosure } from './makeServerClosure'
 
 export const createInstance = (opts: ServerArgs) => {
-  const closure = {
-    ...opts,
-    model: {
-      Subscription: createModel({
-        model: Subscription,
-        table:
-          opts.tableNames?.subscriptions || 'subscriptionless_subscriptions',
-      }),
-      Connection: createModel({
-        model: Connection,
-        table: opts.tableNames?.connections || 'subscriptionless_connections',
-      }),
-    },
-    mapper: new DataMapper({ client: opts.dynamodb }),
-  } as const
+  const closure: ServerClosure = makeServerClosure(opts)
 
   return {
     gatewayHandler: handleGatewayEvent(closure),

--- a/lib/makeServerClosure.ts
+++ b/lib/makeServerClosure.ts
@@ -1,0 +1,22 @@
+import { DataMapper } from '@aws/dynamodb-data-mapper'
+import { ServerArgs, ServerClosure } from './types'
+import { createModel } from './model/createModel'
+import { Subscription } from './model/Subscription'
+import { Connection } from './model/Connection'
+
+export function makeServerClosure(opts: ServerArgs): ServerClosure {
+  return {
+    ...opts,
+    model: {
+      Subscription: createModel({
+        model: Subscription,
+        table: opts.tableNames?.subscriptions || 'subscriptionless_subscriptions',
+      }),
+      Connection: createModel({
+        model: Connection,
+        table: opts.tableNames?.connections || 'subscriptionless_connections',
+      }),
+    },
+    mapper: new DataMapper({ client: opts.dynamodb }),
+  }
+}

--- a/lib/messages/connection_init.ts
+++ b/lib/messages/connection_init.ts
@@ -1,21 +1,20 @@
 import { StepFunctions } from 'aws-sdk'
 import { ConnectionInitMessage, MessageType } from 'graphql-ws'
-import { StateFunctionInput } from '../types'
+import { StateFunctionInput, MessageHandler } from '../types'
 import { deleteConnection, sendMessage } from '../utils/aws'
-import { MessageHandler } from './types'
 
 /** Handler function for 'connection_init' message. */
 export const connection_init: MessageHandler<ConnectionInitMessage> =
-  async ({ c, event, message }) => {
+  async ({ server, event, message }) => {
     try {
-      const res = c.onConnectionInit
-        ? await c.onConnectionInit({ event, message })
+      const res = server.onConnectionInit
+        ? await server.onConnectionInit({ event, message })
         : message.payload
 
-      if (c.pingpong) {
+      if (server.pingpong) {
         await new StepFunctions()
           .startExecution({
-            stateMachineArn: c.pingpong.machine,
+            stateMachineArn: server.pingpong.machine,
             name: event.requestContext.connectionId!,
             input: JSON.stringify({
               connectionId: event.requestContext.connectionId!,
@@ -23,25 +22,25 @@ export const connection_init: MessageHandler<ConnectionInitMessage> =
               stage: event.requestContext.stage,
               state: 'PING',
               choice: 'WAIT',
-              seconds: c.pingpong.delay,
+              seconds: server.pingpong.delay,
             } as StateFunctionInput),
           })
           .promise()
       }
 
       // Write to persistence
-      const connection = Object.assign(new c.model.Connection(), {
+      const connection = Object.assign(new server.model.Connection(), {
         id: event.requestContext.connectionId!,
         requestContext: event.requestContext,
         payload: res,
       })
-      await c.mapper.put(connection)
-      return sendMessage(c)({
+      await server.mapper.put(connection)
+      return sendMessage(server)({
         ...event.requestContext,
         message: { type: MessageType.ConnectionAck },
       })
     } catch (err) {
-      await c.onError?.(err, { event, message })
-      await deleteConnection(c)(event.requestContext)
+      await server.onError?.(err, { event, message })
+      await deleteConnection(server)(event.requestContext)
     }
   }

--- a/lib/messages/ping.ts
+++ b/lib/messages/ping.ts
@@ -1,18 +1,18 @@
 import { PingMessage, MessageType } from 'graphql-ws'
 import { deleteConnection, sendMessage } from '../utils/aws'
-import { MessageHandler } from './types'
+import { MessageHandler } from '../types'
 
 /** Handler function for 'ping' message. */
 export const ping: MessageHandler<PingMessage> =
-  async ({ c, event, message }) => {
+  async ({ server, event, message }) => {
     try {
-      await c.onPing?.({ event, message })
-      return sendMessage(c)({
+      await server.onPing?.({ event, message })
+      return sendMessage(server)({
         ...event.requestContext,
         message: { type: MessageType.Pong },
       })
     } catch (err) {
-      await c.onError?.(err, { event, message })
-      await deleteConnection(c)(event.requestContext)
+      await server.onError?.(err, { event, message })
+      await deleteConnection(server)(event.requestContext)
     }
   }

--- a/lib/messages/pong.ts
+++ b/lib/messages/pong.ts
@@ -1,14 +1,14 @@
 import { PongMessage } from 'graphql-ws'
 import { deleteConnection } from '../utils/aws'
-import { MessageHandler } from './types'
+import { MessageHandler } from '../types'
 
 /** Handler function for 'pong' message. */
 export const pong: MessageHandler<PongMessage> =
-  async ({ c, event, message }) => {
+  async ({ server, event, message }) => {
     try {
-      await c.onPong?.({ event, message })
-      await c.mapper.update(
-        Object.assign(new c.model.Connection(), {
+      await server.onPong?.({ event, message })
+      await server.mapper.update(
+        Object.assign(new server.model.Connection(), {
           id: event.requestContext.connectionId!,
           hasPonged: true,
         }),
@@ -17,7 +17,7 @@ export const pong: MessageHandler<PongMessage> =
         },
       )
     } catch (err) {
-      await c.onError?.(err, { event, message })
-      await deleteConnection(c)(event.requestContext)
+      await server.onError?.(err, { event, message })
+      await deleteConnection(server)(event.requestContext)
     }
   }

--- a/lib/messages/subscribe-test.ts
+++ b/lib/messages/subscribe-test.ts
@@ -1,0 +1,107 @@
+import { assert } from 'chai'
+import { tables } from '@architect/sandbox'
+import { subscribe } from './subscribe'
+import { mockServerContext } from '../test/mockServerContext'
+import { connection_init } from './connection_init'
+import { equals } from '@aws/dynamodb-expressions'
+import { collect } from 'streaming-iterables'
+
+const connectionId = '7rWmyMbMr'
+const ConnectionId = connectionId
+const connectionInitEvent: any = { requestContext: { connectedAt: 1628905962601, connectionId, domainName: 'localhost:6001', eventType: 'MESSAGE', messageDirection: 'IN', messageId: 'Pn6evkpk2', requestId: 'gN1MPybyL', requestTimeEpoch: 1628905962602, routeKey: '$default', stage: 'testing' }, isBase64Encoded: false, body: '{"type":"connection_init"}' }
+
+describe('messages/subscribe', () => {
+  before(async () => {
+    await tables.start({ cwd: './mocks/arc-basic-events', quiet: true })
+  })
+
+  after(async () => {
+    tables.end()
+  })
+
+  it('executes a query/mutation', async () => {
+    const event: any = { requestContext: { connectedAt: 1628889982819, connectionId, domainName: 'localhost:3339', eventType: 'MESSAGE', messageDirection: 'IN', messageId: 'b6o5BPxb3', requestId: 'MaEe0DVon', requestTimeEpoch: 1628889983319, routeKey: '$default', stage: 'testing' }, isBase64Encoded: false, body: '{"id":"abcdefg","type":"subscribe","payload":{"query":"{ hello }"}}' }
+    const state: { delete: { ConnectionId: string }[], post: { ConnectionId: string, Data: string }[] } = { post: [], delete: [] }
+    const server = await mockServerContext({
+      apiGatewayManagementApi: {
+        postToConnection: (input) => ({ promise: async () => { state.post.push(input) } }),
+        deleteConnection: (input) => ({ promise: async () => { state.delete.push(input) } }),
+      },
+    })
+    await connection_init({ server, event: connectionInitEvent, message: JSON.parse(connectionInitEvent.body) })
+    await subscribe({ server, event, message: JSON.parse(event.body) })
+    assert.deepEqual(state, {
+      post: [
+        { ConnectionId, Data: JSON.stringify({ type: 'connection_ack' }) },
+        { ConnectionId, Data: JSON.stringify({ type: 'next', id: 'abcdefg', payload: { data: { hello: 'Hello World!' } } }) },
+        { ConnectionId, Data: JSON.stringify({ type: 'complete', id: 'abcdefg' }) },
+      ],
+      delete: [],
+    })
+  })
+
+  it('records a subscription', async () => {
+    const event: any = { requestContext: { connectedAt: 1628889984369, connectionId, domainName: 'localhost:3339', eventType: 'MESSAGE', messageDirection: 'IN', messageId: 'el4MNdOJy', requestId: '0yd7bkvXz', requestTimeEpoch: 1628889984774, routeKey: '$default', stage: 'testing' }, isBase64Encoded: false, body: '{"id":"1234","type":"subscribe","payload":{"query":"subscription { greetings }"}}' }
+    const state: { delete: { ConnectionId: string }[], post: { ConnectionId: string, Data: string }[] } = { post: [], delete: [] }
+    const server = await mockServerContext({
+      apiGatewayManagementApi: {
+        postToConnection: (input) => ({ promise: async () => { state.post.push(input) } }),
+        deleteConnection: (input) => ({ promise: async () => { state.delete.push(input) } }),
+      },
+    })
+    await connection_init({ server, event: connectionInitEvent, message: JSON.parse(connectionInitEvent.body) })
+    await subscribe({ server, event, message: JSON.parse(event.body) })
+    assert.deepEqual(state, {
+      post: [
+        { ConnectionId, Data: JSON.stringify({ type: 'connection_ack' }) },
+      ],
+      delete: [],
+    })
+    const [subscriptions] = await collect(server.mapper.query(server.model.Subscription, { connectionId: equals(event.requestContext.connectionId) }, { indexName: 'ConnectionIndex' }))
+    assert.include(subscriptions, { connectionId, subscriptionId: '1234' })
+  })
+
+  it('disconnects on error', async () => {
+    const event: any = { requestContext: { connectedAt: 1628889982819, connectionId, domainName: 'localhost:3339', eventType: 'MESSAGE', messageDirection: 'IN', messageId: 'b6o5BPxb3', requestId: 'MaEe0DVon', requestTimeEpoch: 1628889983319, routeKey: '$default', stage: 'testing' }, isBase64Encoded: false, body: '{"id":"abcdefg","type":"subscribe","payload":{"query":"{ HIHOWEAREYOU }"}}' }
+    const state: { delete: { ConnectionId: string }[], post: { ConnectionId: string, Data: string }[] } = { post: [], delete: [] }
+    const server = await mockServerContext({
+      apiGatewayManagementApi: {
+        postToConnection: (input) => ({ promise: async () => { state.post.push(input) } }),
+        deleteConnection: (input) => ({ promise: async () => { state.delete.push(input) } }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onError: undefined,
+    })
+    await connection_init({ server, event: connectionInitEvent, message: JSON.parse(connectionInitEvent.body) })
+    await subscribe({ server, event, message: JSON.parse(event.body) })
+    assert.deepEqual(state, {
+      post: [
+        { ConnectionId, Data: JSON.stringify({ type: 'connection_ack' }) },
+      ],
+      delete: [
+        { ConnectionId },
+      ],
+    })
+  })
+  it('calls the global error callback on error', async () => {
+    const event: any = { requestContext: { connectedAt: 1628889982819, connectionId, domainName: 'localhost:3339', eventType: 'MESSAGE', messageDirection: 'IN', messageId: 'b6o5BPxb3', requestId: 'MaEe0DVon', requestTimeEpoch: 1628889983319, routeKey: '$default', stage: 'testing' }, isBase64Encoded: false, body: '{"id":"abcdefg","type":"subscribe","payload":{"query":"{ HIHOWEAREYOU }"}}' }
+    let error: any = null
+    const server = await mockServerContext({
+      apiGatewayManagementApi: {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        postToConnection: () => ({ promise: async () => { } }),
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        deleteConnection: () => ({ promise: async () => { } }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onError: err => (error = err),
+    })
+    await connection_init({ server, event: connectionInitEvent, message: JSON.parse(connectionInitEvent.body) })
+    await subscribe({ server, event, message: JSON.parse(event.body) })
+    assert.match(error.message, /Cannot query field "HIHOWEAREYOU" on type "Query"/ )
+  })
+  describe('callbacks', () => {
+    it('fires onSubscribe before subscribing')
+    it('fires onAfterSubscribe after subscribing')
+  })
+})

--- a/lib/messages/types.ts
+++ b/lib/messages/types.ts
@@ -1,3 +1,0 @@
-import { APIGatewayWebSocketEvent, ServerClosure } from '../types'
-
-export type MessageHandler<T> = (arg: { c: ServerClosure, event: APIGatewayWebSocketEvent, message: T }) => Promise<void>

--- a/lib/pubsub/complete.ts
+++ b/lib/pubsub/complete.ts
@@ -1,9 +1,11 @@
+import AggregateError from 'aggregate-error'
 import { parse } from 'graphql'
 import { CompleteMessage, MessageType } from 'graphql-ws'
 import { buildExecutionContext } from 'graphql/execution/execute'
 import { ServerClosure, PubSubEvent, SubscribePsuedoIterable } from '../types'
 import { sendMessage } from '../utils/aws'
 import { constructContext, getResolverAndArgs } from '../utils/graphql'
+import { isArray } from '../utils/isArray'
 import { getFilteredSubs } from './getFilteredSubs'
 
 export const complete = (c: ServerClosure) => async (event: PubSubEvent): Promise<void> => {
@@ -29,8 +31,8 @@ export const complete = (c: ServerClosure) => async (event: PubSubEvent): Promis
       undefined,
     )
 
-    if (!('operation' in execContext)) {
-      throw execContext
+    if (isArray(execContext)) {
+      throw new AggregateError(execContext)
     }
 
     const [field, root, args, context, info] = getResolverAndArgs(c)(execContext)

--- a/lib/pubsub/subscribe.ts
+++ b/lib/pubsub/subscribe.ts
@@ -44,7 +44,7 @@ export const concat =
 const createHandler = (topicDefinitions: SubscriptionDefinition[]) => {
   // eslint-disable-next-line require-yield
   const handler: any = function *() {
-    throw Error('Subscription handler should not have been called')
+    throw new Error('Subscription handler should not have been called')
   }
   handler.topicDefinitions = topicDefinitions
   return handler as SubscribePsuedoIterable

--- a/lib/test/integration-basic-events-test.ts
+++ b/lib/test/integration-basic-events-test.ts
@@ -5,18 +5,11 @@ import WebSocket from 'ws'
 import { deferGenerator } from 'inside-out-async'
 import { collect, map } from 'streaming-iterables'
 
-before(async () => {
-  await sandBoxStart({ port: '3339', cwd: './mocks/arc-basic-events', quiet: true } as any)
-})
-
-after(async () => {
-  await new Promise(resolve => setTimeout(resolve, 100)) // pending ddb writes need to finish
-  await sandBoxStop()
-})
+const url = `ws://localhost:${process.env.PORT}`
 
 const executeQuery = async (query: string) => {
   const client = createClient({
-    url: 'ws://localhost:3339',
+    url,
     webSocketImpl: WebSocket,
   })
 
@@ -35,7 +28,7 @@ const executeQuery = async (query: string) => {
 
 const executeSubscription = async (query: string) => {
   const client = createClient({
-    url: 'ws://localhost:3339',
+    url,
     webSocketImpl: WebSocket,
   })
 
@@ -58,6 +51,14 @@ const executeSubscription = async (query: string) => {
 }
 
 describe('Basic Events', () => {
+  before(async () => {
+    await sandBoxStart({ cwd: './mocks/arc-basic-events', quiet: true })
+  })
+
+  after(async () => {
+    await new Promise(resolve => setTimeout(resolve, 100)) // pending ddb writes need to finish
+    await sandBoxStop()
+  })
   it('queries', async () => {
     const result = await executeQuery('{ hello }')
     assert.deepEqual(result, { hello: 'Hello World!' })

--- a/lib/test/mockServerContext.ts
+++ b/lib/test/mockServerContext.ts
@@ -1,0 +1,58 @@
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { tables as arcTables } from '@architect/functions'
+import { makeServerClosure } from '../makeServerClosure'
+import { ServerArgs, ServerClosure } from '../types'
+import { subscribe } from '../pubsub/subscribe'
+
+
+const typeDefs = `
+  type Query {
+    hello: String
+  }
+  type Subscription {
+    greetings: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: () => 'Hello World!',
+  },
+  Subscription: {
+    greetings:{
+      subscribe: subscribe('greetings'),
+      resolve: ({payload}) => {
+        return payload
+      },
+    },
+  },
+}
+
+const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+})
+
+
+export const mockServerContext = async (args: Partial<ServerArgs>): Promise<ServerClosure> => {
+  const tables = await arcTables()
+
+  const ensureName = (table) => {
+    const actualTableName = tables.name(table)
+    if (!actualTableName) {
+      throw new Error(`No table found for ${table}`)
+    }
+    return actualTableName
+  }
+
+  return makeServerClosure({
+    dynamodb: arcTables.db,
+    schema,
+    tableNames: {
+      connections: ensureName('Connection'),
+      subscriptions: ensureName('Subscription'),
+    },
+    onError: (err) => { console.log('onError'); throw err },
+    ...args,
+  })
+}

--- a/lib/test/setupPorts.js
+++ b/lib/test/setupPorts.js
@@ -1,0 +1,2 @@
+process.env.PORT = '6001'
+process.env.ARC_TABLES_PORT = '7002'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,14 +10,14 @@ import {
   APIGatewayProxyEvent,
 } from 'aws-lambda'
 import { GraphQLResolveInfo, GraphQLSchema } from 'graphql'
-import { ApiGatewayManagementApi, DynamoDB } from 'aws-sdk'
+import { DynamoDB } from 'aws-sdk'
 import { Subscription } from './model/Subscription'
 import { Connection } from './model/Connection'
 
 export type ServerArgs = {
   schema: GraphQLSchema
   dynamodb: DynamoDB
-  apiGatewayManagementApi?: ApiGatewayManagementApi
+  apiGatewayManagementApi?: ApiGatewayManagementApiSubset
   context?: ((arg: { connectionParams: any }) => object) | object
   tableNames?: Partial<TableNames>
   pingpong?: {
@@ -104,4 +104,15 @@ export interface APIGatewayWebSocketEvent extends APIGatewayProxyEvent {
 export type PubSubEvent = {
   topic: string
   payload: any
+}
+
+export type MessageHandler<T> = (arg: { server: ServerClosure, event: APIGatewayWebSocketEvent, message: T }) => Promise<void>
+
+
+/*
+  Matches the ApiGatewayManagementApi class from aws-sdk but only provides the methods we use
+*/
+export interface ApiGatewayManagementApiSubset {
+  postToConnection(input: { ConnectionId: string, Data: string }): { promise: () => Promise<void> }
+  deleteConnection(input: { ConnectionId: string }): { promise: () => Promise<void> }
 }

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,2 +1,1 @@
-export const addHours = (date: Date, hours: number) =>
-  new Date(date.valueOf() + hours * 1000 * 60 * 60)
+export const addHours = (date: Date, hours: number): Date => new Date(date.valueOf() + hours * 1000 * 60 * 60)

--- a/lib/utils/isArray.ts
+++ b/lib/utils/isArray.ts
@@ -1,0 +1,1 @@
+export const isArray = <T, B>(input: T | readonly B[]): input is readonly B[] => Array.isArray(input)

--- a/mocks/arc-basic-events/lib/graphql.js
+++ b/mocks/arc-basic-events/lib/graphql.js
@@ -83,6 +83,10 @@ const buildSubscriptionServer = async () => {
       subscriptions: ensureName('Subscription'),
     },
     apiGatewayManagementApi: FakeApiGatewayManagementApi,
+    onError: err => {
+      console.log('onError', err)
+      throw err
+    },
   })
   return server
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,21 @@
       "integrity": "sha512-w+U9klEtRkt7hyW/f+/SvwPgJ4CTMO2ENddisX9dGgLUZKu+iKpb/IhYnQWIt9/Nnm/5DkApmiHGimPs621wwA==",
       "dev": true
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -742,6 +757,22 @@
         "url-join": "^4.0.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -792,6 +823,22 @@
         "tempy": "^1.0.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -858,6 +905,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/architect__sandbox": {
@@ -1185,6 +1256,12 @@
         }
       }
     },
+    "acorn-walk": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
+      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1195,13 +1272,19 @@
       }
     },
     "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.0.tgz",
+      "integrity": "sha512-8DGp7zUt1E9k0NE2q4jlXHk+V3ORErmwolEdRz9iV+LKJ40WhMHh92cxAvhqV2I+zEn/gotIoqoMs0NjF3xofg==",
       "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+        }
       }
     },
     "ajv": {
@@ -1312,6 +1395,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -1569,12 +1658,6 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
     "builtin-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
@@ -1730,10 +1813,19 @@
       "dev": true
     },
     "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.1.0.tgz",
+      "integrity": "sha512-dxXQYI7mfQVcaF12s6sjNFoZ6ZPDQuBBLp3QJ5156k9EvUFClUoZ11fo8HnLQO241DDVntHEug8MOuFO5PSfRg==",
+      "requires": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -1991,6 +2083,12 @@
         }
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2140,6 +2238,12 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "p-map": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -2147,6 +2251,18 @@
           "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
+          },
+          "dependencies": {
+            "aggregate-error": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+              "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+              "dev": true,
+              "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+              }
+            }
           }
         }
       }
@@ -2405,10 +2521,18 @@
       }
     },
     "esbuild": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
-      "dev": true
+      "version": "0.12.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
+      "integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q=="
+    },
+    "esbuild-register": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.0.0.tgz",
+      "integrity": "sha512-No7U3ZUd6gPrrC6gqdb3XFcf2lNqzn8nvQXcgcyOl8szMVuN6YUvOplnmakxWyogI9d8SiJMl0uzBzJck+Aoxw==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -3578,6 +3702,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3893,6 +4023,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "map-obj": {
       "version": "4.2.1",
@@ -7108,6 +7244,22 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7789,25 +7941,37 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
-    "ts-eager": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ts-eager/-/ts-eager-2.0.2.tgz",
-      "integrity": "sha512-xzFPL2z7mgLs0brZXaIHTm91Pjl/Cuu9AMKprgSuK+kIS2LjiG8fqqg4eqz3tgBy9OIdupb9w55pr7ea3JBB+Q==",
+    "ts-node": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
+      "integrity": "sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.11.20",
-        "source-map-support": "^0.5.19"
+        "@cspotcode/source-map-support": "0.6.1",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
       },
       "dependencies": {
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
+        "acorn": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         }
       }
     },
@@ -8311,6 +8475,12 @@
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "tsc && eslint lib/**/*.ts lib/*.ts",
     "format": "eslint lib/**/*.ts lib/*.ts --fix",
     "clean": "rm -rf dist-ts dist",
-    "build": "npm run clean && tsc -p tsconfig-build.json && rollup -c && ts-eager bundle-types",
+    "build": "npm run clean && tsc -p tsconfig-build.json && rollup -c && node -r esbuild-register bundle-types",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release"
   },
@@ -34,7 +34,9 @@
   "dependencies": {
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
-    "@aws/dynamodb-expressions": "^0.7.3"
+    "@aws/dynamodb-expressions": "^0.7.3",
+    "aggregate-error": "^4.0.0",
+    "esbuild": "^0.12.20"
   },
   "peerDependencies": {
     "aws-sdk": ">= 2.844.0",
@@ -54,6 +56,7 @@
     "@typescript-eslint/parser": "^4.27.0",
     "aws-sdk": ">= 2.844.0",
     "chai": "^4.3.4",
+    "esbuild-register": "^3.0.0",
     "eslint": "^7.29.0",
     "graphql": ">= 14.0.0",
     "graphql-ws": "^5.3.0",
@@ -63,7 +66,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "semantic-release": "^17.4.4",
     "streaming-iterables": "^6.0.0",
-    "ts-eager": "^2.0.2",
+    "ts-node": "^10.2.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.5",
     "ws": "^8.0.0"
@@ -72,8 +75,9 @@
     "bail": true,
     "timeout": "100s",
     "require": [
-      "ts-eager/register",
-      "chai/register-assert"
+      "esbuild-register",
+      "chai/register-assert",
+      "./lib/test/setupPorts"
     ],
     "spec": "lib/**/*-test.ts"
   }


### PR DESCRIPTION
- rename internal server closure representation from c to server
- test the subscribe handler a bunch
- switch from ts-eager to esbuild-require
- always throw an error (using aggregate Error) instead of arrays of errors
- run tests on nonstandard sandbox ports
- remove unecessary awaits 
- cleanup array checking