### PR TITLE
docs: `graphql-ws` does provide subprotocol level ping/pong

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ const instance = makeServer({
 
 ### Ping/Pong
 
-For whatever reason, AWS API Gateway does not support WebSocket protocol level ping/pong. This means early detection of unclean client disconnects a lot of extra work as [(graphql-ws doesn't provide subprotocol level ping/pong)](https://github.com/enisdenjo/graphql-ws/issues/117). So you can use Step Functions to do this. See [`pingPong`](docs/interfaces/ServerArgs.md#pingpong).
+For whatever reason, AWS API Gateway does not support WebSocket protocol level ping/pong. So you can use Step Functions to do this. See [`pingPong`](docs/interfaces/ServerArgs.md#pingpong).
 
 ### Socket idleness
 


### PR DESCRIPTION
Removed statement is not true as of [`graphql-ws@v5.0.0`](https://github.com/enisdenjo/graphql-ws/releases/tag/v5.0.0) with https://github.com/enisdenjo/graphql-ws/pull/201.

This could also make the ["Socket idleness"](https://github.com/reconbot/graphql-lambda-subscriptions#socket-idleness) section obsolete, but I am not quite sure of how/if you've approached this, so I'll just let that part be.