### PR TITLE
fix: issues with disconnecting and completing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Connection
   ttl TTL
 Subscription
   id *String
-  topic **String
   ttl TTL
 
 @indexes
@@ -209,8 +208,6 @@ resources:
         KeySchema:
           - AttributeName: id
             KeyType: HASH
-          - AttributeName: topic
-            KeyType: RANGE
         GlobalSecondaryIndexes:
           - IndexName: ConnectionIndex
             KeySchema:
@@ -259,7 +256,6 @@ resource "aws_dynamodb_table" "subscriptions-table" {
   read_capacity  = 1
   write_capacity = 1
   hash_key = "id"
-  range_key = "topic"
 
   attribute {
     name = "id"

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,6 @@ graphql-lambda-subscriptions
 - [LoggerFunction](README.md#loggerfunction)
 - [MaybePromise](README.md#maybepromise)
 - [SubscribeArgs](README.md#subscribeargs)
-- [SubscriptionDefinition](README.md#subscriptiondefinition)
 - [SubscriptionFilter](README.md#subscriptionfilter)
 - [WebSocketResponse](README.md#websocketresponse)
 
@@ -34,11 +33,11 @@ graphql-lambda-subscriptions
 
 ### LoggerFunction
 
-Ƭ **LoggerFunction**: (`message`: `string`, `obj?`: `any`) => `void`
+Ƭ **LoggerFunction**: (`message`: `string`, `obj`: `Record`<`string`, `any`\>) => `void`
 
 #### Type declaration
 
-▸ (`message`, `obj?`): `void`
+▸ (`message`, `obj`): `void`
 
 Log operational events with a logger of your choice. It will get a message and usually object with relevant data
 
@@ -47,7 +46,7 @@ Log operational events with a logger of your choice. It will get a message and u
 | Name | Type |
 | :------ | :------ |
 | `message` | `string` |
-| `obj?` | `any` |
+| `obj` | `Record`<`string`, `any`\> |
 
 ##### Returns
 
@@ -78,26 +77,6 @@ ___
 | `TRoot` | `unknown` |
 | `TArgs` | `Record`<`string`, `any`\> |
 | `TContext` | `unknown` |
-
-___
-
-### SubscriptionDefinition
-
-Ƭ **SubscriptionDefinition**<`T`, `TSubscribeArgs`\>: `Object`
-
-#### Type parameters
-
-| Name | Type |
-| :------ | :------ |
-| `T` | extends [`PubSubEvent`](interfaces/PubSubEvent.md) |
-| `TSubscribeArgs` | extends [`SubscribeArgs`](README.md#subscribeargs)[`SubscribeArgs`](README.md#subscribeargs) |
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `filter?` | [`SubscriptionFilter`](README.md#subscriptionfilter)<`TSubscribeArgs`, `T`[``"payload"``]\> |
-| `topic` | `string` |
 
 ___
 

--- a/docs/interfaces/ServerArgs.md
+++ b/docs/interfaces/ServerArgs.md
@@ -108,7 +108,7 @@ ___
 
 ### onConnectionInit
 
-▸ `Optional` **onConnectionInit**(`e`): [`MaybePromise`](../README.md#maybepromise)<`object`\>
+▸ `Optional` **onConnectionInit**(`e`): [`MaybePromise`](../README.md#maybepromise)<`Record`<`string`, `any`\>\>
 
 #### Parameters
 
@@ -120,7 +120,7 @@ ___
 
 #### Returns
 
-[`MaybePromise`](../README.md#maybepromise)<`object`\>
+[`MaybePromise`](../README.md#maybepromise)<`Record`<`string`, `any`\>\>
 
 ___
 

--- a/docs/interfaces/SubscribePseudoIterable.md
+++ b/docs/interfaces/SubscribePseudoIterable.md
@@ -29,7 +29,8 @@
 
 ### Properties
 
-- [topicDefinitions](SubscribePseudoIterable.md#topicdefinitions)
+- [filter](SubscribePseudoIterable.md#filter)
+- [topic](SubscribePseudoIterable.md#topic)
 
 ### Methods
 
@@ -39,9 +40,15 @@
 
 ## Properties
 
-### topicDefinitions
+### filter
 
-• **topicDefinitions**: [`SubscriptionDefinition`](../README.md#subscriptiondefinition)<`T`, `TSubscribeArgs`\>[]
+• `Optional` **filter**: [`SubscriptionFilter`](../README.md#subscriptionfilter)<`TSubscribeArgs`, `T`[``"payload"``]\>
+
+___
+
+### topic
+
+• **topic**: `string`
 
 ## Methods
 

--- a/lib/buildServerClosure.ts
+++ b/lib/buildServerClosure.ts
@@ -1,8 +1,8 @@
-import { ServerArgs, ServerClosure, Connection, Subscription } from './types'
+import { ServerArgs, ServerClosure } from './types'
 import { DDB } from './ddb/DDB'
 import { log as debugLogger } from './utils/logger'
 
-export const makeServerClosure = async (opts: ServerArgs): Promise<ServerClosure> => {
+export const buildServerClosure = async (opts: ServerArgs): Promise<ServerClosure> => {
   const {
     tableNames,
     log = debugLogger,
@@ -19,8 +19,8 @@ export const makeServerClosure = async (opts: ServerArgs): Promise<ServerClosure
     dynamodb: dynamodb,
     log,
     models: {
-      subscription: DDB<Subscription>({ dynamodb, tableName:  (await tableNames)?.subscriptions || 'graphql_subscriptions', log }),
-      connection: DDB<Connection>({ dynamodb, tableName:  (await tableNames)?.connections || 'graphql_connections', log }),
+      subscription: DDB({ dynamodb, tableName: (await tableNames)?.subscriptions || 'graphql_subscriptions', log }),
+      connection: DDB({ dynamodb, tableName: (await tableNames)?.connections || 'graphql_connections', log }),
     },
   }
 }

--- a/lib/ddb/DDB.ts
+++ b/lib/ddb/DDB.ts
@@ -1,15 +1,15 @@
 import { DynamoDB } from 'aws-sdk'
 import { LoggerFunction, DDBType } from '../types'
 
-export interface DDBClient<T extends DDBType> {
-  get: (id: string) => Promise<T|null>
-  put: (Item: T) => Promise<T>
-  update: (id: string, obj: Partial<T>) => Promise<T>
-  delete: (id: string) => Promise<T>
+export interface DDBClient<T extends DDBType, TKey> {
+  get: (Key: TKey) => Promise<T|null>
+  put: (obj: T) => Promise<T>
+  update: (Key: TKey, obj: Partial<T>) => Promise<T>
+  delete: (Key: TKey) => Promise<T>
   query: (options: Omit<DynamoDB.DocumentClient.QueryInput, 'TableName' | 'Select'>) => AsyncGenerator<T, void, undefined>
 }
 
-export const DDB = <T extends DDBType>({
+export const DDB = <T extends DDBType, TKey>({
   dynamodb,
   tableName,
   log,
@@ -17,77 +17,109 @@ export const DDB = <T extends DDBType>({
   dynamodb: DynamoDB
   tableName: string
   log: LoggerFunction
-}): DDBClient<T> => {
+}): DDBClient<T, TKey> => {
   const documentClient = new DynamoDB.DocumentClient({ service: dynamodb })
 
-  const get = async (id: string): Promise<null | T> => {
-    log('get', { tableName: tableName, id })
-    const { Item } = await documentClient.get({
-      TableName: tableName,
-      Key: { id },
-    }).promise()
-    return (Item as T) ?? null
+  const get = async (Key: TKey): Promise<null | T> => {
+    log('get', { tableName: tableName, Key })
+    try {
+      const { Item } = await documentClient.get({
+        TableName: tableName,
+        Key,
+      }).promise()
+      log('get:result', { Item })
+      return (Item as T) ?? null
+    } catch (e) {
+      log('get:error', e)
+      throw e
+    }
   }
 
   const put = async (Item: T): Promise<T> => {
     log('put', { tableName: tableName, Item })
-    const { Attributes } = await documentClient.put({
-      TableName: tableName,
-      Item,
-      ReturnValues: 'ALL_OLD',
-    }).promise()
-    return Attributes as T
+    try {
+      const { Attributes } = await documentClient.put({
+        TableName: tableName,
+        Item,
+        ReturnValues: 'ALL_OLD',
+      }).promise()
+      return Attributes as T
+    } catch (e) {
+      log('put:error', e)
+      throw e
+    }
   }
 
-  const update = async (id: string, obj: Partial<T>) => {
-    const AttributeUpdates = Object.entries(obj)
-      .map(([key, Value]) => ({ [key]: { Value, Action: 'PUT' } }))
-      .reduce((memo, val) => ({ ...memo, ...val }))
+  const update = async (Key: TKey, obj: Partial<T>) => {
+    log('update', { tableName: tableName, Key, obj })
+    try {
+      const AttributeUpdates = Object.entries(obj)
+        .map(([key, Value]) => ({ [key]: { Value, Action: 'PUT' } }))
+        .reduce((memo, val) => ({ ...memo, ...val }))
 
-    const { Attributes } = await documentClient.update({
-      TableName: tableName,
-      Key: { id },
-      AttributeUpdates,
-      ReturnValues: 'ALL_NEW',
-    }).promise()
-    return Attributes as T
+      const { Attributes } = await documentClient.update({
+        TableName: tableName,
+        Key,
+        AttributeUpdates,
+        ReturnValues: 'ALL_NEW',
+      }).promise()
+      return Attributes as T
+    } catch (e) {
+      log('update:error', e)
+      throw e
+    }
   }
 
-  const deleteFunction = async (id: string): Promise<T> => {
-    const { Attributes } = await documentClient.delete({
-      TableName: tableName,
-      Key: { id },
-      ReturnValues: 'ALL_OLD',
-    }).promise()
-    return Attributes as T
+  const deleteFunction = async (Key: TKey): Promise<T> => {
+    log('delete', { tableName: tableName, Key })
+    try {
+      const { Attributes } = await documentClient.delete({
+        TableName: tableName,
+        Key,
+        ReturnValues: 'ALL_OLD',
+      }).promise()
+      return Attributes as T
+    } catch (e) {
+      log('delete:error', e)
+      throw e
+    }
   }
 
   const queryOnce = async (options: Omit<DynamoDB.DocumentClient.QueryInput, 'TableName' | 'Select'>) => {
-    log('queryOnce', options)
+    log('queryOnce', { tableName: tableName, options })
+    try {
+      const response = await documentClient.query({
+        TableName: tableName,
+        Select: 'ALL_ATTRIBUTES',
+        ...options,
+      }).promise()
 
-    const response = await documentClient.query({
-      TableName: tableName,
-      Select: 'ALL_ATTRIBUTES',
-      ...options,
-    }).promise()
-
-    const { Items, LastEvaluatedKey, Count } = response
-    return {
-      items: (Items ?? []) as T[],
-      lastEvaluatedKey: LastEvaluatedKey,
-      count: Count ?? 0,
+      const { Items, LastEvaluatedKey, Count } = response
+      return {
+        items: (Items ?? []) as T[],
+        lastEvaluatedKey: LastEvaluatedKey,
+        count: Count ?? 0,
+      }
+    } catch (e) {
+      log('queryOnce:error', e)
+      throw e
     }
   }
 
   async function* query(options: Omit<DynamoDB.DocumentClient.QueryInput, 'TableName' | 'Select'>) {
-    log('query', options)
-    const results = await queryOnce(options)
-    yield* results.items
-    let lastEvaluatedKey = results.lastEvaluatedKey
-    while (lastEvaluatedKey) {
-      const results = await queryOnce({ ...options, ExclusiveStartKey: lastEvaluatedKey })
+    log('query', { tableName: tableName, options })
+    try {
+      const results = await queryOnce(options)
       yield* results.items
-      lastEvaluatedKey = results.lastEvaluatedKey
+      let lastEvaluatedKey = results.lastEvaluatedKey
+      while (lastEvaluatedKey) {
+        const results = await queryOnce({ ...options, ExclusiveStartKey: lastEvaluatedKey })
+        yield* results.items
+        lastEvaluatedKey = results.lastEvaluatedKey
+      }
+    } catch (e) {
+      log('query:error', e)
+      throw e
     }
   }
 

--- a/lib/handleStepFunctionEvent.ts
+++ b/lib/handleStepFunctionEvent.ts
@@ -12,7 +12,7 @@ export const handleStepFunctionEvent = (serverPromise: Promise<ServerClosure>): 
   // Initial state - send ping message
   if (input.state === 'PING') {
     await postToConnection(server)({ ...input, message: { type: MessageType.Ping } })
-    await server.models.connection.update(input.connectionId, { hasPonged: false })
+    await server.models.connection.update({ id: input.connectionId }, { hasPonged: false })
     return {
       ...input,
       state: 'REVIEW',
@@ -21,7 +21,7 @@ export const handleStepFunctionEvent = (serverPromise: Promise<ServerClosure>): 
   }
 
   // Follow up state - check if pong was returned
-  const conn = await server.models.connection.get(input.connectionId)
+  const conn = await server.models.connection.get({ id: input.connectionId })
   if (conn?.hasPonged) {
     return {
       ...input,

--- a/lib/handleWebSocketEvent.ts
+++ b/lib/handleWebSocketEvent.ts
@@ -10,7 +10,7 @@ import { pong } from './messages/pong'
 export const handleWebSocketEvent = (serverPromise: Promise<ServerClosure>): SubscriptionServer['webSocketHandler'] => async (event) => {
   const server = await serverPromise
   if (!event.requestContext) {
-    server.log('handleWebSocketEvent unknown')
+    server.log('handleWebSocketEvent unknown', { event })
     return {
       statusCode: 200,
       body: '',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,10 +3,10 @@ import { publish } from './pubsub/publish'
 import { complete } from './pubsub/complete'
 import { handleWebSocketEvent } from './handleWebSocketEvent'
 import { handleStepFunctionEvent } from './handleStepFunctionEvent'
-import { makeServerClosure } from './makeServerClosure'
+import { buildServerClosure } from './buildServerClosure'
 
 export const makeServer = (opts: ServerArgs): SubscriptionServer => {
-  const closure: Promise<ServerClosure> = makeServerClosure(opts)
+  const closure: Promise<ServerClosure> = buildServerClosure(opts)
 
   return {
     webSocketHandler: handleWebSocketEvent(closure),
@@ -32,7 +32,6 @@ export {
   WebSocketResponse,
   StateFunctionInput,
   PubSubEvent,
-  SubscriptionDefinition,
   SubscriptionFilter,
   Connection,
   Subscription,

--- a/lib/messages/complete.ts
+++ b/lib/messages/complete.ts
@@ -13,7 +13,7 @@ export const complete: MessageHandler<CompleteMessage> =
   async ({ server, event, message }) => {
     server.log('messages:complete', { connectionId: event.requestContext.connectionId })
     try {
-      const subscription = await server.models.subscription.get(`${event.requestContext.connectionId}|${message.id}`)
+      const subscription = await server.models.subscription.get({ id: `${event.requestContext.connectionId}|${message.id}` })
       if (!subscription) {
         return
       }
@@ -37,7 +37,7 @@ export const complete: MessageHandler<CompleteMessage> =
       server.log('messages:complete:onComplete', { onComplete: !!onComplete })
       await onComplete?.(root, args, context, info)
 
-      await server.models.subscription.delete(subscription.id)
+      await server.models.subscription.delete({ id: subscription.id })
     } catch (err) {
       server.log('messages:complete:onError', { err, event })
       await server.onError?.(err, { event, message })

--- a/lib/messages/disconnect.ts
+++ b/lib/messages/disconnect.ts
@@ -6,63 +6,49 @@ import { getResolverAndArgs } from '../utils/getResolverAndArgs'
 import { SubscribePseudoIterable, MessageHandler, PubSubEvent } from '../types'
 import { isArray } from '../utils/isArray'
 import { collect } from 'streaming-iterables'
-import { Connection } from '../types'
 
 /** Handler function for 'disconnect' message. */
 export const disconnect: MessageHandler<null> = async ({ server, event }) => {
-  server.log('messages:disconnect', { connectionId: event.requestContext.connectionId })
+  const { connectionId } = event.requestContext
+  server.log('messages:disconnect', { connectionId })
   try {
     await server.onDisconnect?.({ event })
 
     const topicSubscriptions = await collect(server.models.subscription.query({
       IndexName: 'ConnectionIndex',
       ExpressionAttributeNames: { '#a': 'connectionId' },
-      ExpressionAttributeValues: { ':1': event.requestContext.connectionId },
+      ExpressionAttributeValues: { ':1': connectionId },
       KeyConditionExpression: '#a = :1',
     }))
 
-    const completed = {} as Record<string, boolean>
-    const deletions = [] as Promise<void|Connection>[]
-    for (const sub of topicSubscriptions) {
-      deletions.push(
-        (async () => {
-          // only call onComplete per subscription
-          if (!completed[sub.subscriptionId]) {
-            completed[sub.subscriptionId] = true
+    const deletions = topicSubscriptions.map(async (sub) => {
+      const queryContext = await buildContext({ server, connectionInitPayload: sub.connectionInitPayload, connectionId })
 
-            const execContext = buildExecutionContext(
-              server.schema,
-              parse(sub.subscription.query),
-              undefined,
-              await buildContext({ server, connectionInitPayload: sub.connectionInitPayload, connectionId: sub.connectionId }),
-              sub.subscription.variables,
-              sub.subscription.operationName,
-              undefined,
-            )
-
-            if (isArray(execContext)) {
-              throw new AggregateError(execContext)
-            }
-
-
-            const [field, root, args, context, info] = getResolverAndArgs(server)(execContext)
-
-            const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
-            server.log('messages:disconnect:onComplete', { onComplete: !!onComplete })
-            await onComplete?.(root, args, context, info)
-          }
-
-          await server.models.subscription.delete(sub.id)
-        })(),
+      const execContext = buildExecutionContext(
+        server.schema,
+        parse(sub.subscription.query),
+        undefined,
+        queryContext,
+        sub.subscription.variables,
+        sub.subscription.operationName,
+        undefined,
       )
-    }
 
-    await Promise.all([
-      // Delete subscriptions
-      ...deletions,
-      // Delete connection
-      server.models.connection.delete(event.requestContext.connectionId),
-    ])
+      if (isArray(execContext)) {
+        throw new AggregateError(execContext)
+      }
+
+      const [field, root, args, context, info] = getResolverAndArgs(server)(execContext)
+
+      const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
+      server.log('messages:disconnect:onComplete', { onComplete: !!onComplete })
+      await onComplete?.(root, args, context, info)
+      await server.models.subscription.delete({ id: sub.id })
+    })
+
+    // do this first so that we don't create any more subscriptions for this connection
+    await server.models.connection.delete({ id: connectionId }),
+    await Promise.all(deletions)
   } catch (err) {
     server.log('messages:disconnect:onError', { err, event })
     await server.onError?.(err, { event })

--- a/lib/messages/pong.ts
+++ b/lib/messages/pong.ts
@@ -7,7 +7,7 @@ export const pong: MessageHandler<PongMessage> =
   async ({ server, event, message }) => {
     try {
       await server.onPong?.({ event, message })
-      await server.models.connection.update(event.requestContext.connectionId, {
+      await server.models.connection.update({ id: event.requestContext.connectionId }, {
         hasPonged: true,
       })
     } catch (err) {

--- a/lib/pubsub/complete.ts
+++ b/lib/pubsub/complete.ts
@@ -12,7 +12,7 @@ import { getFilteredSubs } from './getFilteredSubs'
 export const complete = (serverPromise: Promise<ServerClosure> | ServerClosure): SubscriptionServer['complete'] => async event => {
   const server = await serverPromise
   const subscriptions = await getFilteredSubs({ server, event })
-  server.log('pubsub:complete %j', { event, subscriptions })
+  server.log('pubsub:complete', { event, subscriptions })
 
   const iters = subscriptions.map(async (sub) => {
     const message: CompleteMessage = {
@@ -23,7 +23,7 @@ export const complete = (serverPromise: Promise<ServerClosure> | ServerClosure):
       ...sub.requestContext,
       message,
     })
-    await server.models.subscription.delete(sub.id)
+    await server.models.subscription.delete({ id: sub.id })
 
     const execContext = buildExecutionContext(
       server.schema,

--- a/lib/pubsub/getFilteredSubs-test.ts
+++ b/lib/pubsub/getFilteredSubs-test.ts
@@ -27,7 +27,7 @@ describe('collapseKeys', () => {
 let count = 1
 const makeTopic = () => `topic-${count++}`
 
-describe.only('getFilteredSubs', () => {
+describe('getFilteredSubs', () => {
   before(async () => {
     await tables.start({ cwd: './mocks/arc-basic-events', quiet: true })
   })

--- a/lib/pubsub/getFilteredSubs.ts
+++ b/lib/pubsub/getFilteredSubs.ts
@@ -4,7 +4,7 @@ import { ServerClosure, Subscription } from '../types'
 
 export const getFilteredSubs = async ({ server, event }: { server: Omit<ServerClosure, 'gateway'>, event: { topic: string, payload?: Record<string, any> } }): Promise<Subscription[]> => {
   if (!event.payload || Object.keys(event.payload).length === 0) {
-    server.log('getFilteredSubs %j', { event })
+    server.log('getFilteredSubs', { event })
 
     const iterator = server.models.subscription.query({
       IndexName: 'TopicIndex',
@@ -29,7 +29,7 @@ export const getFilteredSubs = async ({ server, event }: { server: Omit<ServerCl
     filterExpressions.push(`(#filter.#${aliasNumber} = :${aliasNumber} OR attribute_not_exists(#filter.#${aliasNumber}))`)
   }
 
-  server.log('getFilteredSubs %j', { event, expressionAttributeNames, expressionAttributeValues, filterExpressions })
+  server.log('getFilteredSubs', { event, expressionAttributeNames, expressionAttributeValues, filterExpressions })
 
   const iterator = server.models.subscription.query({
     IndexName: 'TopicIndex',

--- a/lib/pubsub/publish.ts
+++ b/lib/pubsub/publish.ts
@@ -7,9 +7,9 @@ import { getFilteredSubs } from './getFilteredSubs'
 
 export const publish = (serverPromise: Promise<ServerClosure> | ServerClosure): SubscriptionServer['publish'] => async event => {
   const server = await serverPromise
-  server.log('pubsub:publish %j', { event })
+  server.log('pubsub:publish', { event })
   const subscriptions = await getFilteredSubs({ server, event })
-  server.log('pubsub:publish %j', { subscriptions: subscriptions.map(({ connectionId, filter, subscription }) => ({ connectionId, filter, subscription }) ) })
+  server.log('pubsub:publish', { subscriptions: subscriptions.map(({ connectionId, filter, subscription }) => ({ connectionId, filter, subscription }) ) })
 
   const iters = subscriptions.map(async (sub) => {
     const payload = await execute(

--- a/lib/pubsub/subscribe.ts
+++ b/lib/pubsub/subscribe.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { PubSubEvent, SubscribeArgs, SubscribeOptions, SubscribePseudoIterable, SubscriptionDefinition } from '../types'
+import { PubSubEvent, SubscribeArgs, SubscribeOptions, SubscribePseudoIterable } from '../types'
 
 /**
  * Creates subscribe handler for use in your graphql schema.
@@ -19,11 +19,9 @@ export const subscribe = <T extends PubSubEvent, TRoot extends any = any, TArgs 
     onComplete,
     onAfterSubscribe,
   } = options
-  const handler = createHandler<T>([{
-    topic,
-    filter,
-  }])
-
+  const handler = createHandler<T>()
+  handler.topic = topic
+  handler.filter = filter
   handler.onSubscribe = onSubscribe
   handler.onComplete = onComplete
   handler.onAfterSubscribe = onAfterSubscribe
@@ -31,11 +29,10 @@ export const subscribe = <T extends PubSubEvent, TRoot extends any = any, TArgs 
   return handler
 }
 
-const createHandler = <T extends PubSubEvent>(topicDefinitions: SubscriptionDefinition<T>[]) => {
+const createHandler = <T extends PubSubEvent>() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any,require-yield
   const handler: any = async function* () {
     throw new Error('Subscription handler should not have been called')
   }
-  handler.topicDefinitions = topicDefinitions
   return handler as SubscribePseudoIterable<T>
 }

--- a/lib/test/mockServer.ts
+++ b/lib/test/mockServer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { makeExecutableSchema } from '@graphql-tools/schema'
 import { tables as arcTables } from '@architect/functions'
-import { makeServerClosure } from '../makeServerClosure'
+import { buildServerClosure } from '../buildServerClosure'
 import { ServerArgs, ServerClosure } from '../types'
 import { subscribe } from '../pubsub/subscribe'
 
@@ -63,5 +63,5 @@ export const mockServerArgs = async (args: Partial<ServerArgs> = {}): Promise<Se
 }
 
 export const mockServerContext = async (args?: Partial<ServerArgs>): Promise<ServerClosure> => {
-  return makeServerClosure(await mockServerArgs(args))
+  return buildServerClosure(await mockServerArgs(args))
 }

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -3,6 +3,6 @@ import debug from 'debug'
 const logger = debug('graphql-lambda-subscriptions')
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-const log = (message: string, obj?: any): void => logger(message, obj)
+const log = (message: string, obj: Record<string, any>): void => logger(`${message} %j`, obj)
 
 export { log }

--- a/lib/utils/postToConnection.ts
+++ b/lib/utils/postToConnection.ts
@@ -23,7 +23,7 @@ export const postToConnection = (server: ServerClosure) =>
     stage: string
     message: GraphqlWSMessages
   }): Promise<void> => {
-    server.log('sendMessage %j', { connectionId: ConnectionId, message })
+    server.log('sendMessage', { connectionId: ConnectionId, message })
 
     const api = server.apiGatewayManagementApi ??
       new ApiGatewayManagementApi({

--- a/mocks/arc-basic-events/app.arc
+++ b/mocks/arc-basic-events/app.arc
@@ -9,7 +9,6 @@ Connection
   ttl TTL
 Subscription
   id *String
-  topic **String
   ttl TTL
 
 @indexes


### PR DESCRIPTION
Part of the DDB refactor messed up which keys we needed to remove a record. Upon investigation we had a "topic" as a range key because we used to allow multiple topics per subscription. I'm pulling that out for the time being.

- add more logging and fixup the logging function's input
- Better DDB logging
- The logger function now always gets the object, the type change is additive so it's not a breaking change (I kind of want to move pino for logging and add a concept of log level)
- DDB can now support range keys even though we don't use them

BREAKING CHANGE: The subscriptions Table has has its range key removed. This will require a migration.

