### PR TITLE
fix: args that are inline weren't passed to callback functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   plugins: [
     '@typescript-eslint',
+    'mocha-no-only',
   ],
   rules: {
     '@typescript-eslint/member-delimiter-style': ['error', {
@@ -32,6 +33,7 @@ module.exports = {
     'object-curly-spacing': ['error', 'always'],
     'quote-props': ['error', 'as-needed'],
     'space-infix-ops': ['error'],
+    "mocha-no-only/mocha-no-only": ["error"],
     indent: ['error', 2],
     quotes: ['error', 'single'],
     semi: 'off',

--- a/lib/messages/complete.ts
+++ b/lib/messages/complete.ts
@@ -9,38 +9,37 @@ import { getResolverAndArgs } from '../utils/getResolverAndArgs'
 import { isArray } from '../utils/isArray'
 
 /** Handler function for 'complete' message. */
-export const complete: MessageHandler<CompleteMessage> =
-  async ({ server, event, message }) => {
-    server.log('messages:complete', { connectionId: event.requestContext.connectionId })
-    try {
-      const subscription = await server.models.subscription.get({ id: `${event.requestContext.connectionId}|${message.id}` })
-      if (!subscription) {
-        return
-      }
-      const execContext = buildExecutionContext(
-        server.schema,
-        parse(subscription.subscription.query),
-        undefined,
-        await buildContext({ server, connectionInitPayload: subscription.connectionInitPayload, connectionId: subscription.connectionId }),
-        subscription.subscription.variables,
-        subscription.subscription.operationName,
-        undefined,
-      )
-
-      if (isArray(execContext)) {
-        throw new AggregateError(execContext)
-      }
-
-      const [field, root, args, context, info] = getResolverAndArgs(server)(execContext)
-
-      const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
-      server.log('messages:complete:onComplete', { onComplete: !!onComplete })
-      await onComplete?.(root, args, context, info)
-
-      await server.models.subscription.delete({ id: subscription.id })
-    } catch (err) {
-      server.log('messages:complete:onError', { err, event })
-      await server.onError?.(err, { event, message })
-      await deleteConnection(server)(event.requestContext)
+export const complete: MessageHandler<CompleteMessage> = async ({ server, event, message }) => {
+  server.log('messages:complete', { connectionId: event.requestContext.connectionId })
+  try {
+    const subscription = await server.models.subscription.get({ id: `${event.requestContext.connectionId}|${message.id}` })
+    if (!subscription) {
+      return
     }
+    const execContext = buildExecutionContext(
+      server.schema,
+      parse(subscription.subscription.query),
+      undefined,
+      await buildContext({ server, connectionInitPayload: subscription.connectionInitPayload, connectionId: subscription.connectionId }),
+      subscription.subscription.variables,
+      subscription.subscription.operationName,
+      undefined,
+    )
+
+    if (isArray(execContext)) {
+      throw new AggregateError(execContext)
+    }
+
+    const { field, root, args, context, info } = getResolverAndArgs({ server, execContext })
+
+    const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
+    server.log('messages:complete:onComplete', { onComplete: !!onComplete })
+    await onComplete?.(root, args, context, info)
+
+    await server.models.subscription.delete({ id: subscription.id })
+  } catch (err) {
+    server.log('messages:complete:onError', { err, event })
+    await server.onError?.(err, { event, message })
+    await deleteConnection(server)(event.requestContext)
   }
+}

--- a/lib/messages/disconnect.ts
+++ b/lib/messages/disconnect.ts
@@ -38,7 +38,7 @@ export const disconnect: MessageHandler<null> = async ({ server, event }) => {
         throw new AggregateError(execContext)
       }
 
-      const [field, root, args, context, info] = getResolverAndArgs(server)(execContext)
+      const { field, root, args, context, info } = getResolverAndArgs({ server, execContext })
 
       const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
       server.log('messages:disconnect:onComplete', { onComplete: !!onComplete })
@@ -47,7 +47,7 @@ export const disconnect: MessageHandler<null> = async ({ server, event }) => {
     })
 
     // do this first so that we don't create any more subscriptions for this connection
-    await server.models.connection.delete({ id: connectionId }),
+    await server.models.connection.delete({ id: connectionId })
     await Promise.all(deletions)
   } catch (err) {
     server.log('messages:disconnect:onError', { err, event })

--- a/lib/pubsub/complete.ts
+++ b/lib/pubsub/complete.ts
@@ -39,7 +39,7 @@ export const complete = (serverPromise: Promise<ServerClosure> | ServerClosure):
       throw new AggregateError(execContext)
     }
 
-    const [field, root, args, context, info] = getResolverAndArgs(server)(execContext)
+    const { field, root, args, context, info } = getResolverAndArgs({ server, execContext })
 
     const onComplete = (field?.subscribe as SubscribePseudoIterable<PubSubEvent>)?.onComplete
     server.log('pubsub:complete:onComplete', { onComplete: !!onComplete })

--- a/lib/test/execute-helper.ts
+++ b/lib/test/execute-helper.ts
@@ -185,11 +185,13 @@ export const executeDoubleQuery = async function* (query: string, {
   stayConnected = false,
   timeout = 20_000,
   id = 1,
+  skipWaitingForFirstMessage = false,
 }: {
   url?: string
   stayConnected?: boolean
   timeout?: number
   id?: number
+  skipWaitingForFirstMessage?: boolean
 } = {}): AsyncGenerator<unknown, void, unknown> {
   const ws = new WebSocket(url, 'graphql-transport-ws')
 
@@ -235,11 +237,13 @@ export const executeDoubleQuery = async function* (query: string, {
     payload: { query },
   })
 
-  const firstMessage = await incomingMessages.generator.next()
-  if (firstMessage.done) {
-    return
+  if (!skipWaitingForFirstMessage) {
+    const firstMessage = await incomingMessages.generator.next()
+    if (firstMessage.done) {
+      return
+    }
+    yield firstMessage.value
   }
-  yield firstMessage.value
 
   await send({
     id: `${id}`,

--- a/lib/test/graphql-ws-schema.ts
+++ b/lib/test/graphql-ws-schema.ts
@@ -9,6 +9,7 @@ const PORT = 4000
 const typeDefs = `
   type Query {
     hello: String
+    dontResolve: String
   }
   type Subscription {
     greetings: String
@@ -21,6 +22,8 @@ const typeDefs = `
 const resolvers = {
   Query: {
     hello: () => 'Hello World!',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    dontResolve: () => new Promise(() => {}),
   },
   Subscription: {
     greetings:{

--- a/lib/test/integration-events-test.ts
+++ b/lib/test/integration-events-test.ts
@@ -65,7 +65,20 @@ describe('Events', () => {
       await stop()
     })
 
-    it('errors when duplicating subscription ids', async () => {
+    // it('errors when duplicating subscription ids with queries', async () => {
+    //   const { url, stop } = await startGqlWSServer()
+
+    //   const lambdaError = await collect(executeDoubleQuery('{ dontResolve }', { id: 1, skipWaitingForFirstMessage: true }))
+    //   const gqlWSError = await collect(executeDoubleQuery('{ dontResolve }', { id: 1, skipWaitingForFirstMessage: true, url }))
+    //   console.log({ lambdaError, gqlWSError })
+    //   assert.deepEqual(lambdaError[0], gqlWSError[0])
+    //   // This would be exactly equal but apigateway doesn't support close reasons *eye roll*
+    //   assert.containSubset(lambdaError[1], { type: 'close' })
+    //   assert.containSubset(gqlWSError[1], { type: 'close' })
+    //   await stop()
+    // })
+
+    it('errors when duplicating subscription ids with subscriptions', async () => {
       const { url, stop } = await startGqlWSServer()
 
       const lambdaError = await collect(executeDoubleQuery('subscription { oneEvent }', { id: 1 }))

--- a/mocks/arc-basic-events/lib/graphql.js
+++ b/mocks/arc-basic-events/lib/graphql.js
@@ -25,6 +25,7 @@ const makeManagementAPI = () => {
 const typeDefs = `
   type Query {
     hello: String
+    dontResolve: String
   }
   type Subscription {
     greetings: String
@@ -41,6 +42,7 @@ const typeDefs = `
 const resolvers = {
   Query: {
     hello: () => 'Hello World!',
+    dontResolve: () => new Promise(() => {}),
   },
   Subscription: {
     greetings:{

--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,6 +2473,15 @@
         }
       }
     },
+    "eslint-plugin-mocha-no-only": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha-no-only/-/eslint-plugin-mocha-no-only-1.1.1.tgz",
+      "integrity": "sha512-b+vgjJQ3SjRQCygBhomtjzvRQRpIP8Yd9cqwNSbcoVJREuNajao7M1Kl1aObAUc4wx98qsZyQyUSUxiAbMS9yA==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6959,6 +6968,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "esbuild": "^0.12.20",
     "esbuild-register": "^3.0.0",
     "eslint": "^7.29.0",
+    "eslint-plugin-mocha-no-only": "^1.1.1",
     "graphql": ">= 14.0.0",
     "graphql-ws": "^5.3.0",
     "inside-out-async": "^1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ export default {
     'aws-sdk',
     'graphql',
     'graphql/execution/execute',
+    'graphql/execution/values',
     // actual deps
     'debug',
     'streaming-iterables',


### PR DESCRIPTION
eg;

```graphql
subscription { 
  greetings(name: "Jonas") 
}
```

Will now work as expected.