### PR TITLE
Ignore gone exceptions

### DIFF
--- a/lib/utils/postToConnection.ts
+++ b/lib/utils/postToConnection.ts
@@ -37,4 +37,8 @@ export const postToConnection = (server: ServerClosure) =>
         Data: JSON.stringify(message),
       })
       .promise()
+      .catch(err => {
+        if (err?.code !== 'GoneException') throw err
+        console.warn('Connection already closed at API Gateway, ignoring')
+      })
   }


### PR DESCRIPTION
It's possible that an API Gateway subscription is already closed by the client when trying to publish. E.g.:

- The client opens a connection, the connection and subscription are stored in DynamoDB.
- The client closes the connection, which might only be handled 200ms later because of a cold start.
- A few milliseconds after closing, the server wants to publish to a subscription. The connection is not yet deleted from DynamoDB so the query returns the closed connection.
- The API Gateway Management API throws a "GoneException" because the connection is closed.

This PR adds a catch block that ignores a GoneException.

This will need further verification.