### PR TITLE
fix: remove ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "exports": {
-    "import": "./dist/index-esm.mjs",
     "require": "./dist/index.js",
     "default": "./dist/index.js"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default {
     }),
   ],
   output: [
-    { format: 'esm', file: './dist/index-esm.mjs' },
+    // { format: 'esm', file: './dist/index-esm.mjs' },
     { format: 'cjs', file: './dist/index.js' },
   ],
   external: [


### PR DESCRIPTION
vitest, vite, and a few other bundlers are having issues with the graphql subpath imports as they're not declared in the graphql export map. This is fine for commonjs but it wreaks havock on esm loaders. I think this is a bug in the commonjs/esm interop but here we are

BREAKING CHANGE: This removes the ESM export from the export maps and the shipped files.